### PR TITLE
Add search widget

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ import view from './view.js';
 import basemapToggle from './widgets/basemapToggle.js';
 import home from './widgets/home.js';
 import locate from './widgets/locate.js';
+import search from './widgets/search.js';
 import zoom from './widgets/zoom.js';
 
+view.ui.add(search, 'top-left');
 view.ui.add(zoom, 'top-left');
 view.ui.add(home, 'top-left');
 view.ui.add(locate, 'top-left');

--- a/src/widgets/search.js
+++ b/src/widgets/search.js
@@ -4,6 +4,9 @@ import buildings from '../layers/buildings.js';
 import sections from '../layers/sections.js';
 import view from '../view.js';
 
+/**
+ * Widget that searches for buildings and lots.
+ */
 export default new Expand({
   view,
   expandIcon: 'search',

--- a/src/widgets/search.js
+++ b/src/widgets/search.js
@@ -1,0 +1,35 @@
+import Expand from '@arcgis/core/widgets/Expand';
+import Search from '@arcgis/core/widgets/Search';
+import buildings from '../layers/buildings.js';
+import sections from '../layers/sections.js';
+import view from '../view.js';
+
+export default new Expand({
+  view,
+  expandIcon: 'search',
+  expandTooltip: 'Search',
+  content: new Search({
+    view,
+    allPlaceholder: 'Find building or lot',
+    includeDefaultSources: false,
+    locationEnabled: false,
+    sources: [
+      {
+        layer: sections,
+        name: 'Lots',
+        placeholder: 'Find lot',
+        searchFields: ['SectionCode', 'SectionColor', 'SectionName'],
+        displayField: 'SectionName',
+        outFields: ['*'],
+      },
+      {
+        layer: buildings,
+        name: 'Buildings',
+        placeholder: 'Find building',
+        searchFields: ['Building_Name'],
+        displayField: 'Building_Name',
+        outFields: ['*'],
+      },
+    ],
+  }),
+});


### PR DESCRIPTION
Adds a simple Search widget to the map for buildings and lots. 

It leaves a bit to be desired (appears to use `{ARG}%` style queries) but seems to be adequate and pretty much equivalent to the one on the previous map.

Closes #11