### PR TITLE
Add layer list widget

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import view from './view.js';
 import basemapToggle from './widgets/basemapToggle.js';
+import filter from './widgets/filter.js';
 import home from './widgets/home.js';
 import locate from './widgets/locate.js';
 import search from './widgets/search.js';
@@ -9,4 +10,5 @@ view.ui.add(search, 'top-left');
 view.ui.add(zoom, 'top-left');
 view.ui.add(home, 'top-left');
 view.ui.add(locate, 'top-left');
+view.ui.add(filter, 'top-left');
 view.ui.add(basemapToggle, 'bottom-right');

--- a/src/layers/buildings.js
+++ b/src/layers/buildings.js
@@ -13,6 +13,7 @@ export default new FeatureLayer({
     id: 'c048f4a9df6344b19281876740c44ba0',
   },
   title: 'Buildings',
+  listMode: 'hide',
   renderer: {
     type: 'simple',
     symbol: {

--- a/src/layers/spaces.js
+++ b/src/layers/spaces.js
@@ -35,6 +35,7 @@ export default new FeatureLayer({
     )
   `,
   title: 'Spaces',
+  visible: false,
   renderer: {
     type: 'unique-value',
     field: 'ParkingSpaceSubCategory',

--- a/src/widgets/filter.js
+++ b/src/widgets/filter.js
@@ -1,0 +1,12 @@
+import Expand from '@arcgis/core/widgets/Expand';
+import LayerList from '@arcgis/core/widgets/LayerList';
+import view from '../view.js';
+
+export default new Expand({
+  view: view,
+  expandIcon: 'layers',
+  expandTooltip: 'Filter',
+  content: new LayerList({
+    view,
+  }),
+});

--- a/src/widgets/filter.js
+++ b/src/widgets/filter.js
@@ -2,6 +2,9 @@ import Expand from '@arcgis/core/widgets/Expand';
 import LayerList from '@arcgis/core/widgets/LayerList';
 import view from '../view.js';
 
+/**
+ * Widget that controls feature visibility.
+ */
 export default new Expand({
   view: view,
   expandIcon: 'layers',


### PR DESCRIPTION
Adds a simple LayerList widget to the map to control layer visibility

As mentioned in the issue, takes us as far as we can go with the API (which is not very far). Allows turning the lot/spaces layer on/off.

Closes #12